### PR TITLE
feat: implement first version of event publishing interface

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    extends: 'hapi',
+    parserOptions: {
+        ecmaVersion: 9
+    }
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,17 @@
 'use strict';
 
-module.exports = () => {
 
-};
+class Client {
+
+    constructor(transport) {
+
+        this.transport = transport;
+    }
+
+    publish(stream, eventType, data) {
+
+        return this.transport.publish(stream, eventType, data);
+    }
+}
+
+module.exports = Client;

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,8 @@
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 
+const Client = require('../index');
+
 const lab = exports.lab = Lab.script();
 const { it, describe } = lab;
 const expect = Code.expect;
@@ -11,8 +13,26 @@ describe('event sourcing client', () => {
 
     it('should be exported as function', () => {
 
-        const Client = require('../index');
-
         expect(typeof Client).to.equal('function');
+    });
+
+    it('should delegate publishing to configured transport', () => {
+
+        const stream = 'chats';
+        const eventType = 'chatCreated';
+        const data = { key: 'value' };
+
+        const transport = {
+            publish: (_stream, _eventType, _data) => ({
+                stream: _stream,
+                eventType: _eventType,
+                data: _data
+            })
+        };
+        const client = new Client(transport);
+
+        expect(client.publish(stream, eventType, data)).to.equal({
+            stream, eventType, data
+        });
     });
 });


### PR DESCRIPTION
This is the first idea for an interface for event publishing.

This client would be in charge of handling publishing of events to the event sourcing service. 

The intent is for this client to be an abstraction over whatever protocol/transport/service we decide to use for event publishing and consumption. The client delegates publishing to a transport that would be the one doing the actual publishing implementation.

Example Usage:

```javascript
const transport = new RabbitMQTransport(rabbitUrl, { exchangeName: 'events', ...moreOptions });
client = new EventSourcingClient(transport);
const stream = 'chats'
const type = 'created'
const data = { id: 1, user: 1, context: { type: 'triage', intent: 'get_care' } }
client.publish('chats', 'created', data)
```

Then the client would be published using the configured transport ... a Transport just needs to implement a publish function with same parameters.