### PR TITLE
fix: isolate actual data within event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:10.16@sha256:0f291a2ef67db1cdf10bd04cddfc90f798b670bc13c84068875b850ec25af27d
+    - image: circleci/node:10.16@sha256:d87d8bfd5fb9a6130a1a0684839032bf4722eed3a8b06277d050fcd928e43c70
 
 jobs:
   test:

--- a/lib/transports/single-key-rabbit.js
+++ b/lib/transports/single-key-rabbit.js
@@ -30,7 +30,7 @@ class RabbitTransport {
 
         return exchange.publish(
             {
-                ...data,
+                data,
                 stream,
                 streamId,
                 eventType

--- a/test/transports/single-key-rabbit.js
+++ b/test/transports/single-key-rabbit.js
@@ -30,7 +30,7 @@ describe('event sourcing client rabbit transport', () => {
         expect(info.calledOnce).to.equal(true);
         expect(publish.calledOnce).to.equal(true);
         expect(publish.getCall(0).args).to.equal([
-            { id: 1, stream: 'chats', streamId: 'xyz', eventType: 'created' },
+            { data: { id: 1 }, stream: 'chats', streamId: 'xyz', eventType: 'created' },
             { key: 'events.chats.created' }
         ]);
     });


### PR DESCRIPTION
so we can easily extract high level fields like `stream` from the entirety of the full event data